### PR TITLE
Adding flattener kata

### DIFF
--- a/flattener/flatten.js
+++ b/flattener/flatten.js
@@ -1,0 +1,31 @@
+// flatten([], 4, [5, 6, 7 [3, [4, 5, 7]]]) = [1, 3, 4, 6, 8, 9]
+// and sort the result 
+
+module.exports = class Flattener {
+
+    flatten(nestedList) {
+        const listOfFlatten = []
+        nestedList.forEach(element => {
+            if (typeof element == Array) {
+                flatten(element);
+            } else {
+                listOfFlatten.push(element);
+            }
+        });
+        return listOfFlatten
+    }
+
+    sortListInAscendingOrder(listToSort) {
+        let tempValue;
+        listToSort.forEach((currentValue, index) => {
+            for (let i = 0; i < listToSort.length; i++) {
+                if (currentValue < listToSort[i]) {
+                    tempValue = listToSort[index];
+                    listToSort[index] = listToSort[i];
+                    listToSort[i] = tempValue;
+                }
+            }
+        })
+        return listToSort;
+    }
+}

--- a/flattener/test/flatten.spec.js
+++ b/flattener/test/flatten.spec.js
@@ -1,0 +1,49 @@
+const Flattener = require("../flatten");
+
+describe('Flattener', () => {
+
+    it('should return a flat list', () => {
+        const flattener = new Flattener()
+
+        let testSet1 = [2, [2, 3]];
+        let expectedSet = [2, 2, 3];
+
+        let flatList = flattener.flatten(testSet1);
+        
+        const x = expectedSet.toString();
+        const y = flatList.toString();
+        
+        expect(x).toEqual(y);
+    });
+
+    it('should return a flat list on 2 level nested or more', () => {
+        const flattener = new Flattener()
+
+        let testSet = [2, [2, 3, [4, 5, 7, [5, 6, 8]], [5, 6, 7]]];
+        let expectedSet = [2, 2, 3, 4, 5, 7, 5, 6, 8, 5, 6, 7];
+
+        let flatList = flattener.flatten(testSet);
+
+        const x = expectedSet.toString();
+        const y = flatList.toString();
+        expect(x).toEqual(y);
+    });
+
+    it('should sort a short list of unordered numbers', () => {
+        const flattener = new Flattener()
+        const listOfUnOrdered = [6, 1, 7];
+        const expectedOrder = [1, 6, 7];
+        
+        const orderedInAscending = flattener.sortListInAscendingOrder(listOfUnOrdered);
+        expect(orderedInAscending).toEqual(expectedOrder);
+    });
+
+    it('should sort a short list of unordered numbers', () => {
+        const flattener = new Flattener()
+        const listOfUnOrdered = [6, 1, 7, 9, 7, 6, 7, 2, 3];
+        const expectedOrder = [1,2,3,6,6,7,7,7,9];
+
+        const orderedInAscending = flattener.sortListInAscendingOrder(listOfUnOrdered);
+        expect(orderedInAscending).toEqual(expectedOrder);
+    });
+});


### PR DESCRIPTION
Flattener
given an array of nested arrays (containing real numbers exclusively)  return a flat array and order the result by ascending
example:
set1 = [3, 4, 6, 1, [3, 5]]
should equal [3, 4, 6, 1,  3, 5] // the order is not important yet as long as the array has no more nested arrays
then sort it:
1, 3, 3, 4, 5, 6